### PR TITLE
op3/t: wifi: enable initial scan for DFS channels.

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -3,7 +3,6 @@
 # defaults for the WLAN Driver
 
 # ifdef VENDOR_EDIT
-gInitialScanNoDFSChnl=1
 gInitialDwellTime=20
 RoamRssiDiff=5
 gEnable2x2=0


### PR DESCRIPTION
  Enabling initial scan for DFS channels reduces the time needed
  to find 5GHz APs (even those not utilizing a DFS channel) from
  20 - 30 seconds to 5 seconds.

Change-Id: Ica5d18b4ab1cd55a3c436d44daabcb5625c200be